### PR TITLE
bugfix: Update parameter-metadata-accessor.ts to prevent TypeError: undefined…

### DIFF
--- a/lib/services/parameter-metadata-accessor.ts
+++ b/lib/services/parameter-metadata-accessor.ts
@@ -54,7 +54,7 @@ export class ParameterMetadataAccessor {
     const parametersWithType: ParamsWithType = mapValues(
       reverseObjectKeys(routeArgsMetadata),
       (param: ParamMetadata) => ({
-        type: types[param.index],
+        type: types && types[param.index] ? types[param.index] : 'string',
         name: param.data,
         required: true
       }) as unknown as ParamsWithType


### PR DESCRIPTION
TypeError: undefined is not an object (evaluating 'types[param.index]')
```
 class ParameterMetadataAccessor {
     explore(instance, prototype, method) {
         const types = Reflect.getMetadata(constants_1.PARAMTYPES_METADATA, instance, method.name);
         const routeArgsMetadata = Reflect.getMetadata(constants_1.ROUTE_ARGS_METADATA, instance.constructor, method.name) || {};
         const parametersWithType = (0, lodash_1.mapValues)((0, reverse_object_keys_util_1.reverseObjectKeys)(routeArgsMetadata), (param) => ({
             type: types[param.index],
                       ^
TypeError: undefined is not an object (evaluating 'types[param.index]')
```
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
TypeError: undefined is not an object (evaluating 'types[param.index]')

Issue Number: N/A


## What is the new behavior?
Set default type to string

## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No



## Other information
